### PR TITLE
Add tag_name to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For more information on these outputs, see the [API Documentation](https://devel
 - `html_url`: The URL users can navigate to in order to view the release. i.e. `https://github.com/octocat/Hello-World/releases/v1.0.0`
 - `upload_url`: The URL for uploading assets to the release, which could be used by GitHub Actions for additional uses, for example the [`@actions/upload-release-asset`](https://www.github.com/actions/upload-release-asset) GitHub Action
 - `created`: The Boolean value of whether a release was created
+- `tag_name`: The name of the created tag_name
 
 ### Example workflow - release with commit
 

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,8 @@ outputs:
     description: 'The URL for uploading assets to the release'
   created:
     description: 'The Boolean value of whether a release was created'
+  tag_name:
+    description: 'The name of the created tag_name'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -110,7 +110,7 @@ function main(github, config, callback, failure) {
             const commits = github_1.context.payload.commits;
             if (commits.length === 0) {
                 core.info("No commits detected!");
-                callback(-1, "", "", false);
+                callback(-1, "", "", false, null);
                 return;
             }
             const headCommit = commits[0];
@@ -119,7 +119,7 @@ function main(github, config, callback, failure) {
             const releaseInfo = config.exec(headCommit.message);
             if (!releaseInfo) {
                 core.info("Commit message does not matched.");
-                callback(-1, "", "", false);
+                callback(-1, "", "", false, null);
                 return;
             }
             // Create a release
@@ -137,7 +137,7 @@ function main(github, config, callback, failure) {
             });
             // Get the ID, html_url, and upload URL for the created Release from the response
             const { data: { id: releaseId, html_url: htmlUrl, upload_url: uploadUrl }, } = createReleaseResponse;
-            callback(releaseId, htmlUrl, uploadUrl, true);
+            callback(releaseId, htmlUrl, uploadUrl, true, releaseInfo);
         }
         catch (error) {
             failure(error);
@@ -165,12 +165,13 @@ function run() {
             repo: repo,
             owner: owner,
         });
-        yield main(github, config, (releaseId, htmlUrl, uploadUrl, created) => {
+        yield main(github, config, (releaseId, htmlUrl, uploadUrl, created, releaseInfo) => {
             // Set the output variables for use by other actions: https://github.com/actions/toolkit/tree/master/packages/core#inputsoutputs
             core.setOutput("id", releaseId);
             core.setOutput("html_url", htmlUrl);
             core.setOutput("upload_url", uploadUrl);
             core.setOutput("created", created);
+            core.setOutput("tag_name", releaseInfo === null || releaseInfo === void 0 ? void 0 : releaseInfo.tag_name);
         }, (error) => {
             core.setFailed(error);
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import * as core from "@actions/core";
 import { context, getOctokit } from "@actions/github";
 import { Config } from "./config";
+import { ReleaseInfo } from "./releaseInfo";
 
 export async function main(
   github: ReturnType<typeof getOctokit>,
@@ -9,7 +10,8 @@ export async function main(
     releaseId: number,
     htmlUrl: string,
     uploadUrl: string,
-    created: boolean
+    created: boolean,
+    releaseInfo: ReleaseInfo | null
   ) => void,
   failure: (error: any) => void
 ) {
@@ -17,7 +19,7 @@ export async function main(
     const commits = context.payload.commits;
     if (commits.length === 0) {
       core.info("No commits detected!");
-      callback(-1, "", "", false);
+      callback(-1, "", "", false, null);
       return;
     }
     const headCommit = commits[0];
@@ -27,7 +29,7 @@ export async function main(
     const releaseInfo = config.exec(headCommit.message);
     if (!releaseInfo) {
       core.info("Commit message does not matched.");
-      callback(-1, "", "", false);
+      callback(-1, "", "", false, null);
       return;
     }
 
@@ -49,7 +51,7 @@ export async function main(
       data: { id: releaseId, html_url: htmlUrl, upload_url: uploadUrl },
     } = createReleaseResponse;
 
-    callback(releaseId, htmlUrl, uploadUrl, true);
+    callback(releaseId, htmlUrl, uploadUrl, true, releaseInfo);
   } catch (error) {
     failure(error);
   }
@@ -80,12 +82,13 @@ async function run(): Promise<void> {
   await main(
     github,
     config,
-    (releaseId, htmlUrl, uploadUrl, created) => {
+    (releaseId, htmlUrl, uploadUrl, created, releaseInfo) => {
       // Set the output variables for use by other actions: https://github.com/actions/toolkit/tree/master/packages/core#inputsoutputs
       core.setOutput("id", releaseId);
       core.setOutput("html_url", htmlUrl);
       core.setOutput("upload_url", uploadUrl);
       core.setOutput("created", created);
+      core.setOutput("tag_name", releaseInfo?.tag_name);
     },
     (error) => {
       core.setFailed(error);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -37,7 +37,7 @@ describe("Config", () => {
     if (!releaseInfo) done();
     if (releaseInfo) {
       expect(releaseInfo.body).toBe(
-        "# Release Test md\r\n\r\n- Test markdown.\r\n"
+        "# Release Test md\n\n- Test markdown.\n"
       );
     }
     done();

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -36,7 +36,9 @@ describe("Config", () => {
     const releaseInfo = config.exec("Release 1.1.1\n\n- Add\n - function");
     if (!releaseInfo) done();
     if (releaseInfo) {
-      expect(releaseInfo.body).toBe("# Release Test md\r\n\r\n- Test markdown.\r\n");
+      expect(releaseInfo.body).toBe(
+        "# Release Test md\r\n\r\n- Test markdown.\r\n"
+      );
     }
     done();
   });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -36,7 +36,7 @@ describe("Config", () => {
     const releaseInfo = config.exec("Release 1.1.1\n\n- Add\n - function");
     if (!releaseInfo) done();
     if (releaseInfo) {
-      expect(releaseInfo.body).toBe("# Release Test md\n\n- Test markdown.\n");
+      expect(releaseInfo.body).toBe("# Release Test md\r\n\r\n- Test markdown.\r\n");
     }
     done();
   });

--- a/test/regex.test.ts
+++ b/test/regex.test.ts
@@ -1,27 +1,23 @@
-
 describe("Regex Example", () => {
+  const regexpString =
+    "Release v((\\d+([.]\\d+)*)-(alpha|beta|rc)\\d*)((\\s|\\S)*)";
 
-    const regexpString = "Release v((\\d+([.]\\d+)*)-(alpha|beta|rc)\\d*)((\\s|\\S)*)"
-
-    test(regexpString, async (done) => {
-        class Param {
-            constructor(
-                public message: string,
-                public $1: string
-            ){}
-        }
-        const params = [
-            new Param("Release v0.0.3-alpha Change to main branch", "0.0.3-alpha"),
-            new Param("Release v0.0.3-alpha1 Change to main branch", "0.0.3-alpha1"),
-            new Param("Release v0.0.3-rc2 Change to main branch", "0.0.3-rc2"),
-        ];
-        const regexp = new RegExp(regexpString, "us");
-        for (const p of params) {
-            if (p.message.replace(regexp, "$1") !== p.$1) {
-                done.fail(p.message);
-                break
-            }
-        }
-        done();
-    });
+  test(regexpString, async (done) => {
+    class Param {
+      constructor(public message: string, public $1: string) {}
+    }
+    const params = [
+      new Param("Release v0.0.3-alpha Change to main branch", "0.0.3-alpha"),
+      new Param("Release v0.0.3-alpha1 Change to main branch", "0.0.3-alpha1"),
+      new Param("Release v0.0.3-rc2 Change to main branch", "0.0.3-rc2"),
+    ];
+    const regexp = new RegExp(regexpString, "us");
+    for (const p of params) {
+      if (p.message.replace(regexp, "$1") !== p.$1) {
+        done.fail(p.message);
+        break;
+      }
+    }
+    done();
+  });
 });


### PR DESCRIPTION
I needed the tag name of the created release for my next workflow steps.

I extended the callback function of the `main` function and added the `releaseInfo` object as parameter, so I could take `tag_name` from there to add it to the action outputs.