### PR TITLE
Add ncc production build verification to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
     - name: build
       run: npm run build
 
+    - name: Verify production build (ncc)
+      run: npm run package
+
     - name: run test
       run: npm run test
 


### PR DESCRIPTION
## Summary
`test.yml` now builds the production bundle (`npm run package`, ncc) on push/PR. It was previously built only by `auto-build.yml` on push to master, so a PR passing `tsc` could still produce a failing ncc bundle that surfaced only after merge.
