### PR TITLE
Explicitly set tsconfig "types" so Jest globals resolve under TypeScript 6.0

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "noImplicitAny": true,
     /* Raise error on expressions and declarations with an implied 'any' type. */
     "forceConsistentCasingInFileNames": true,
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    "types": ["jest", "node"]
   },
   "exclude": ["node_modules", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
Add an explicit `"types": ["jest", "node"]` to `tsconfig.json`. `ts-jest` relies on TypeScript implicit `@types` discovery to load the Jest globals (`describe`/`test`/`expect`); TypeScript 6.0 no longer auto-includes `@types/jest` in this layout, so every test suite fails to compile. Declaring `types` explicitly restores resolution and is a no-op on TypeScript 5.x.

## Verification
Confirmed `npm run build` + `npm test` pass under both TypeScript 5.9.3 (current) and 6.0.3 (pending Dependabot bump). Without this change, 6.0.3 fails test compilation with `TS2593: Cannot find name 'describe'`.