### PR TITLE
Update README usage version to v4.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: ChanTsune/release-with-commit@v2.8.0
+      - uses: ChanTsune/release-with-commit@v4.0.1
         with:
           regexp: "Release ((\\d+([.]\\d+)*)-(alpha|beta|rc)\\d*)((\\s|\\S)*)"
           regexp_options: "us"


### PR DESCRIPTION
## Summary
Update the action version in the README usage example to the current release `v4.0.1` (it was still `v2.8.0`).