### PR TITLE
Bump js-yaml to 3.15.0 / 4.3.0 via lockfile re-resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5898,10 +5898,11 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -7679,10 +7680,21 @@
       }
     },
     "node_modules/standard/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -12905,9 +12917,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -14144,9 +14156,9 @@
           }
         },
         "js-yaml": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-          "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+          "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
           "dev": true,
           "requires": {
             "argparse": "^2.0.1"


### PR DESCRIPTION
Bumps [js-yaml](https://github.com/nodeca/js-yaml) to patched versions across both transitive paths: 3.14.2 → 3.15.0 and 4.1.1 → 4.3.0.

`js-yaml` is not a direct dependency. It enters through two paths, both re-resolved by re-solving the lockfile — no `overrides` were added and `jest` stays at 30.4.2 (Dependabot's own update path would have downgraded it to 25.0.0).

- `ts-jest` → `@jest/transform` → `babel-plugin-istanbul` → `@istanbuljs/load-nyc-config` → `js-yaml@3.14.2` → **3.15.0**
- `standard` → `eslint@8.57.1` (+ `@eslint/eslintrc`) → `js-yaml@4.1.1` → **4.3.0**

## Security fix

Resolves [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) — JS-YAML: Quadratic-complexity DoS in merge key handling via repeated aliases.

- CVE: CVE-2026-53550
- Severity: Moderate (CVSS 5.3)
- Patched: `js-yaml >= 3.15.0` (3.x line); 4.x re-resolved to 4.3.0

## Commits

- Bump js-yaml to 3.15.0 / 4.3.0 via lockfile re-resolution

## Verification

- `npm ls js-yaml` → 3.15.0 and 4.3.0 only; vulnerable 3.14.2 / 4.1.1 gone
- `npm ls jest` → stays at 30.4.2 (no downgrade to 25.0.0)
- `npm audit` → no `js-yaml` findings
- `npm run all` → build, format, lint, package, test all pass
